### PR TITLE
Disambiguate log message for remote conn failure

### DIFF
--- a/bdr.c
+++ b/bdr.c
@@ -167,8 +167,7 @@ bdr_get_remote_dboid(const char *conninfo_db)
 	{
 		ereport(FATAL,
 				(errcode(ERRCODE_CONNECTION_FAILURE),
-				 errmsg("could not connect to the primary server: %s",
-						PQerrorMessage(dbConn)),
+				 errmsg("get remote OID: %s", PQerrorMessage(dbConn)),
 				 errdetail("Connection string is '%s'", conninfo_db)));
 	}
 
@@ -277,8 +276,7 @@ bdr_connect(const char *conninfo,
 	{
 		ereport(ERROR,
 				(errcode(ERRCODE_CONNECTION_FAILURE),
-				 errmsg("could not connect to the primary server: %s",
-						PQerrorMessage(streamConn)),
+				 errmsg("establish BDR: %s", PQerrorMessage(streamConn)),
 				 errdetail("Connection string is '%s'", conninfo_repl.data)));
 	}
 


### PR DESCRIPTION
The current log message suggests that there is one "primary server",
which I found misleading

< 2015-12-24 12:00:37.989 EST >ERROR:  could not connect to the primary server: could not connect to server: Connection refused
                Is the server running on host "10.232.25.92" and accepting
                TCP/IP connections on port 5432?

Instead label the error with the underlying operation that failed
