### PR TITLE
Fix doc tokens exceeding NAMELEN

### DIFF
--- a/doc/manual-functions.sgml
+++ b/doc/manual-functions.sgml
@@ -557,7 +557,7 @@
        </entry>
       </row>
 
-      <row id="function-bdr-connection-set-replication-sets-byname" xreflabel="bdr.connection_set_replication_sets">
+      <row id="function-bdr-connection-set-rep-sets-byname" xreflabel="bdr.connection_set_replication_sets">
        <entry>
         <indexterm>
          <primary>bdr.connection_set_replication_sets</primary>
@@ -575,7 +575,7 @@
        </entry>
       </row>
 
-      <row id="function-bdr-connection-get-replication-sets-byname" xreflabel="bdr.connection_get_replication_sets">
+      <row id="function-bdr-connection-get-rep-sets-byname" xreflabel="bdr.connection_get_replication_sets">
        <entry>
         <indexterm>
          <primary>bdr.connection_get_replication_sets(text)</primary>
@@ -592,7 +592,7 @@
        </entry>
       </row>
 
-      <row id="function-bdr-connection-set-replication-sets-byid" xreflabel="bdr.connection_set_replication_sets">
+      <row id="function-bdr-connection-set-rep-sets-byid" xreflabel="bdr.connection_set_replication_sets">
        <entry>
         <indexterm>
          <primary>bdr.connection_set_replication_sets(text[],text)</primary>
@@ -610,7 +610,7 @@
        </entry>
       </row>
 
-      <row id="function-bdr-connection-get-replication-sets-byid" xreflabel="bdr.connection_get_replication_sets">
+      <row id="function-bdr-connection-get-rep-sets-byid" xreflabel="bdr.connection_get_replication_sets">
        <entry>
         <indexterm>
          <primary>bdr.connection_get_replication_sets</primary>

--- a/doc/manual-replication-sets.sgml
+++ b/doc/manual-replication-sets.sgml
@@ -122,7 +122,7 @@
   </para>
   <para>
    To change one node's replication sets in a running &bdr; cluster, the <xref
-   linkend="function-bdr-connection-set-replication-sets-byname"> functions
+   linkend="function-bdr-connection-set-rep-sets-byname"> functions
    should be used. Changes only need to be made on one node, since BDR
    connection configuration is its self replicated to all other nodes. The
    global DDL lock is not taken by this operation.


### PR DESCRIPTION
Similar to the discussion below about how not all distributions have patched OpenJade to allow longer tag id lengths.  Gentoo is one in particular.

https://www.postgresql.org/message-id/flat/20150515010757.GO5101%40gengoff.gsmr1.local#20150515010757.GO5101@gengoff.gsmr1.local