### PR TITLE
Fix deparsing of CREATE SEQUENCE ... OWNED BY

### DIFF
--- a/src/backend/tcop/deparse_utility.c
+++ b/src/backend/tcop/deparse_utility.c
@@ -3639,7 +3639,7 @@ deparse_CreateSeqStmt(Oid objectId, Node *parsetree)
 	elems = lappend(elems, deparse_Seq_Maxvalue(createSeq, seqdata));
 	elems = lappend(elems, deparse_Seq_Startwith(createSeq, seqdata));
 	elems = lappend(elems, deparse_Seq_Restart(createSeq, seqdata));
-	/* we purposefully do not emit OWNED BY here */
+	elems = lappend(elems, deparse_Seq_OwnedBy(createSeq, objectId));
 
 	append_array_object(createSeq, "definition", elems);
 


### PR DESCRIPTION
Per GitHub #284, CREATE SEQUENCE failed to replicate "OWNED BY".

The relevant code (line 3942) contained this comment:

    /* we purposefully do not emit OWNED BY here */

(introduced in commit d99242f2), but no indication of the reason for doing
this. Deparsing for ALTER SEQUENCE ... OWNED BY was added in the same commit.
I'm unable to determine any issues which could be caused by emitting OWNED BY
here.

No test added as the change is not verifiable with local tests.

A test covering OWNED BY was previously added in commit 18508dc8.